### PR TITLE
Adding element indexes to DiffElement

### DIFF
--- a/DiffLib.Tests/BasicInsertDeleteDiffElementAlignerTests.cs
+++ b/DiffLib.Tests/BasicInsertDeleteDiffElementAlignerTests.cs
@@ -50,9 +50,9 @@ namespace DiffLib.Tests
 
             CollectionAssert.AreEqual(new[]
             {
-                new DiffElement<int>(1, Option<int>.None, DiffOperation.Delete),
-                new DiffElement<int>(2, Option<int>.None, DiffOperation.Delete),
-                new DiffElement<int>(3, Option<int>.None, DiffOperation.Delete),
+                new DiffElement<int>(0, 1, null, Option<int>.None, DiffOperation.Delete),
+                new DiffElement<int>(1, 2, null, Option<int>.None, DiffOperation.Delete),
+                new DiffElement<int>(2, 3, null, Option<int>.None, DiffOperation.Delete),
             }, elements);
         }
 
@@ -73,9 +73,9 @@ namespace DiffLib.Tests
 
             CollectionAssert.AreEqual(new[]
             {
-                new DiffElement<int>(Option<int>.None, 1, DiffOperation.Insert),
-                new DiffElement<int>(Option<int>.None, 2, DiffOperation.Insert),
-                new DiffElement<int>(Option<int>.None, 3, DiffOperation.Insert),
+                new DiffElement<int>(null, Option<int>.None, 0, 1, DiffOperation.Insert),
+                new DiffElement<int>(null, Option<int>.None, 1, 2, DiffOperation.Insert),
+                new DiffElement<int>(null, Option<int>.None, 2, 3, DiffOperation.Insert),
             }, elements);
         }
     }

--- a/DiffLib.Tests/DiffTests.cs
+++ b/DiffLib.Tests/DiffTests.cs
@@ -135,12 +135,12 @@ namespace DiffLib.Tests
 
             CollectionAssert.AreEqual(new[]
             {
-                new DiffElement<string>("Line 1", "Line 1", DiffOperation.Match),
-                new DiffElement<string>(Option<string>.None, null, DiffOperation.Insert),
-                new DiffElement<string>("Line 2", "Line 2", DiffOperation.Match),
-                new DiffElement<string>(null, Option<string>.None, DiffOperation.Delete),
-                new DiffElement<string>("Line 3", Option<string>.None, DiffOperation.Delete),
-                new DiffElement<string>("Line 4", "Line 4", DiffOperation.Match),
+                new DiffElement<string>(0, "Line 1", 0, "Line 1", DiffOperation.Match),
+                new DiffElement<string>(null, Option<string>.None, 1, null, DiffOperation.Insert),
+                new DiffElement<string>(1, "Line 2", 2, "Line 2", DiffOperation.Match),
+                new DiffElement<string>(2, null, null, Option<string>.None, DiffOperation.Delete),
+                new DiffElement<string>(3, "Line 3", null, Option<string>.None, DiffOperation.Delete),
+                new DiffElement<string>(4, "Line 4", 3, "Line 4", DiffOperation.Match),
             }, elements);
         }
     }

--- a/DiffLib.Tests/StringSimilarityDiffElementAlignerTests.cs
+++ b/DiffLib.Tests/StringSimilarityDiffElementAlignerTests.cs
@@ -47,9 +47,9 @@ namespace DiffLib.Tests
 
             CollectionAssert.AreEqual(new[]
             {
-                new DiffElement<string>("Line 1", "Line 1", DiffOperation.Modify),
-                new DiffElement<string>("Line 2", "Line 2", DiffOperation.Modify),
-                new DiffElement<string>("Line 3", "Line 3", DiffOperation.Modify),
+                new DiffElement<string>(0, "Line 1", 0, "Line 1", DiffOperation.Modify),
+                new DiffElement<string>(1, "Line 2", 1, "Line 2", DiffOperation.Modify),
+                new DiffElement<string>(2, "Line 3", 2, "Line 3", DiffOperation.Modify),
             }, elements);
         }
 
@@ -78,10 +78,10 @@ namespace DiffLib.Tests
 
             CollectionAssert.AreEqual(new[]
             {
-                new DiffElement<string>("Line 1", "Line 1", DiffOperation.Modify),
-                new DiffElement<string>("Line 2", "Line+2", DiffOperation.Modify),
-                new DiffElement<string>(null, null, DiffOperation.Modify),
-                new DiffElement<string>("Line 3", "Line 3", DiffOperation.Modify),
+                new DiffElement<string>(0, "Line 1", 0, "Line 1", DiffOperation.Modify),
+                new DiffElement<string>(1, "Line 2", 1, "Line+2", DiffOperation.Modify),
+                new DiffElement<string>(2, null, 2, null, DiffOperation.Modify),
+                new DiffElement<string>(3, "Line 3", 3, "Line 3", DiffOperation.Modify),
             }, elements);
         }
 
@@ -108,10 +108,10 @@ namespace DiffLib.Tests
 
             CollectionAssert.AreEqual(new[]
             {
-                new DiffElement<string>("Line 1", "Line 1", DiffOperation.Modify),
-                new DiffElement<string>("Line 2", Option<string>.None, DiffOperation.Delete),
-                new DiffElement<string>(Option<string>.None, "Something else", DiffOperation.Insert),
-                new DiffElement<string>("Line 3", "Line 3", DiffOperation.Modify),
+                new DiffElement<string>(0, "Line 1", 0, "Line 1", DiffOperation.Modify),
+                new DiffElement<string>(1, "Line 2", null, Option<string>.None, DiffOperation.Delete),
+                new DiffElement<string>(null, Option<string>.None, 1, "Something else", DiffOperation.Insert),
+                new DiffElement<string>(2, "Line 3", 2, "Line 3", DiffOperation.Modify),
             }, elements);
         }
     }

--- a/DiffLib/BasicInsertDeleteDiffElementAligner.cs
+++ b/DiffLib/BasicInsertDeleteDiffElementAligner.cs
@@ -51,10 +51,10 @@ namespace DiffLib
                 throw new ArgumentNullException(nameof(collection2));
 
             for (int index = 0; index < length1; index++)
-                yield return new DiffElement<T>(collection1[start1 + index], Option<T>.None, DiffOperation.Delete);
+                yield return new DiffElement<T>(start1 + index, collection1[start1 + index], null, Option<T>.None, DiffOperation.Delete);
 
             for (int index = 0; index < length2; index++)
-                yield return new DiffElement<T>(Option<T>.None, collection2[start2 + index], DiffOperation.Insert);
+                yield return new DiffElement<T>(null, Option<T>.None, start2 + index, collection2[start2 + index], DiffOperation.Insert);
         }
     }
 }

--- a/DiffLib/BasicReplaceInsertDeleteDiffElementAligner.cs
+++ b/DiffLib/BasicReplaceInsertDeleteDiffElementAligner.cs
@@ -50,7 +50,7 @@ namespace DiffLib
         {
             int replaceCount = Min(length1, length2);
             for (int index = 0; index < replaceCount; index++)
-                yield return new DiffElement<T>(collection1[start1 + index], collection2[start2 + index], DiffOperation.Replace);
+                yield return new DiffElement<T>(start1 + index, collection1[start1 + index], start2 + index, collection2[start2 + index], DiffOperation.Replace);
 
             foreach (var element in base.Align(collection1, start1 + replaceCount, length1 - replaceCount, collection2, start2 + replaceCount, length2 - replaceCount))
                 yield return element;

--- a/DiffLib/Diff.Static.cs
+++ b/DiffLib/Diff.Static.cs
@@ -102,7 +102,7 @@ namespace DiffLib
                 {
                     for (int index = 0; index < section.LengthInCollection1; index++)
                     {
-                        yield return new DiffElement<T>(collection1[start1], collection2[start2], DiffOperation.Match);
+                        yield return new DiffElement<T>(start1, collection1[start1], start2, collection2[start2], DiffOperation.Match);
                         start1++;
                         start2++;
                     }

--- a/DiffLib/DiffElement.cs
+++ b/DiffLib/DiffElement.cs
@@ -14,6 +14,12 @@ namespace DiffLib
         /// <summary>
         /// Constructs a new instance of <see cref="DiffElement{T}"/>.
         /// </summary>
+        /// <param name="elementIndexFromCollection1">
+        /// Index of <see cref="ElementFromCollection1"/> in <c>Collection1</c>.
+        /// </param>
+        /// <param name="elementIndexFromCollection2">
+        /// Index of <see cref="ElementFromCollection2"/> in <c>Collection2</c>.
+        /// </param>
         /// <param name="elementFromCollection1">
         /// The aligned element from the first collection, or <see cref="Option{T}.None"/> if an element from the second collection could
         /// not be aligned with anything from the first.
@@ -25,12 +31,20 @@ namespace DiffLib
         /// <param name="operation">
         /// A <see cref="DiffOperation"/> specifying how <paramref name="elementFromCollection1"/> corresponds to <paramref name="elementFromCollection2"/>.
         /// </param>
-        public DiffElement(Option<T> elementFromCollection1, Option<T> elementFromCollection2, DiffOperation operation)
+        public DiffElement(int? elementIndexFromCollection1, Option<T> elementFromCollection1, 
+            int? elementIndexFromCollection2, Option<T> elementFromCollection2, DiffOperation operation)
         {
+            ElementIndexFromCollection1 = elementIndexFromCollection1;
             ElementFromCollection1 = elementFromCollection1;
+            ElementIndexFromCollection2 = elementIndexFromCollection2;
             ElementFromCollection2 = elementFromCollection2;
             Operation = operation;
         }
+
+        /// <summary>
+        /// Index of <see cref="ElementFromCollection1"/> in <c>Collection1</c>.
+        /// </summary>
+        public int? ElementIndexFromCollection1 { get; }
 
         /// <summary>
         /// The aligned element from the first collection, or <see cref="Option{T}.None"/> if an element from the second collection could
@@ -40,6 +54,11 @@ namespace DiffLib
         {
             get;
         }
+
+        /// <summary>
+        /// Index of <see cref="ElementFromCollection2"/> in <c>Collection2</c>.
+        /// </summary>
+        public int? ElementIndexFromCollection2 { get; }
 
         /// <summary>
         /// The aligned element from the second collection, or <see cref="Option{T}.None"/> if an element from the first collection could
@@ -67,7 +86,12 @@ namespace DiffLib
         /// <param name="other">An object to compare with this object.</param>
         public bool Equals(DiffElement<T> other)
         {
-            return ElementFromCollection1.Equals(other.ElementFromCollection1) && ElementFromCollection2.Equals(other.ElementFromCollection2) && Operation == other.Operation;
+            return 
+                ElementIndexFromCollection1.Equals(other.ElementIndexFromCollection1) &&
+                ElementFromCollection1.Equals(other.ElementFromCollection1) && 
+                ElementIndexFromCollection2.Equals(other.ElementIndexFromCollection2) &&
+                ElementFromCollection2.Equals(other.ElementFromCollection2) &&
+                Operation == other.Operation;
         }
 
         /// <summary>
@@ -119,6 +143,8 @@ namespace DiffLib
             {
                 var hashCode = ElementFromCollection1.GetHashCode();
                 hashCode = (hashCode * 397) ^ ElementFromCollection2.GetHashCode();
+                hashCode = (hashCode * 397) ^ ElementIndexFromCollection1.GetHashCode();
+                hashCode = (hashCode * 397) ^ ElementIndexFromCollection2.GetHashCode();
                 hashCode = (hashCode * 397) ^ (int)Operation;
                 return hashCode;
             }

--- a/DiffLib/ElementSimilarityAligner.cs
+++ b/DiffLib/ElementSimilarityAligner.cs
@@ -121,18 +121,18 @@ namespace DiffLib
                         case DiffOperation.Match:
                         case DiffOperation.Replace:
                         case DiffOperation.Modify:
-                            result.Add(new DiffElement<T>(collection1[start1], collection2[start2], bestNode.Operation));
+                            result.Add(new DiffElement<T>(start1, collection1[start1], start2, collection2[start2], bestNode.Operation));
                             start1++;
                             start2++;
                             break;
 
                         case DiffOperation.Insert:
-                            result.Add(new DiffElement<T>(Option<T>.None, collection2[start2], bestNode.Operation));
+                            result.Add(new DiffElement<T>(null, Option<T>.None, start2, collection2[start2], bestNode.Operation));
                             start2++;
                             break;
 
                         case DiffOperation.Delete:
-                            result.Add(new DiffElement<T>(collection1[start1], Option<T>.None, bestNode.Operation));
+                            result.Add(new DiffElement<T>(start1, collection1[start1], null, Option<T>.None, bestNode.Operation));
                             start1++;
                             break;
 


### PR DESCRIPTION
Adds original collection indexes to `DiffElement<T>`.
Helps with showing line numbers when diffing text files.